### PR TITLE
Fix password column uniqueness and update Maven settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,20 +55,20 @@
     </properties>
 
     <repositories>
-	<repository>
-	    <id>sonatype</id>
-	    <url>http://search.maven.org/remotecontent?filepath=</url>
-	</repository>
+        <repository>
+            <id>sonatype</id>
+            <url>https://repo1.maven.org/maven2/</url>
+        </repository>
         <repository>
             <id>JBOSS</id>
-            <url>http://repository.jboss.org/nexus/content/groups/public</url>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>sonatype mirror</id>
-            <url>http://search.maven.org/remotecontent?filepath=</url>
+            <url>https://repo1.maven.org/maven2/</url>
         </pluginRepository>
     </pluginRepositories>
 
@@ -306,7 +306,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.3.1</version>
                 <inherited>true</inherited>
                 <configuration>
                     <encoding>UTF-8</encoding>

--- a/src/main/java/com/aimprosoft/glossary/common/model/impl/User.java
+++ b/src/main/java/com/aimprosoft/glossary/common/model/impl/User.java
@@ -24,7 +24,7 @@ public class User extends BusinessModel {
     @NotNull
     @NotEmpty
     //hibernate
-    @Column(name = "password", nullable = false, unique = true)
+    @Column(name = "password", nullable = false)
     private String password;
 
     //validation

--- a/src/test/java/com/aimprosoft/glossary/test/UserModelTest.java
+++ b/src/test/java/com/aimprosoft/glossary/test/UserModelTest.java
@@ -1,0 +1,17 @@
+package com.aimprosoft.glossary.test;
+
+import com.aimprosoft.glossary.common.model.impl.User;
+import org.junit.Test;
+
+import javax.persistence.Column;
+
+import static org.junit.Assert.*;
+
+public class UserModelTest {
+    @Test
+    public void passwordColumnShouldNotBeUnique() throws NoSuchFieldException {
+        Column column = User.class.getDeclaredField("password").getAnnotation(Column.class);
+        assertNotNull("password field should have Column annotation", column);
+        assertFalse("password column should not be unique", column.unique());
+    }
+}


### PR DESCRIPTION
## Summary
- Remove unique constraint from `User` entity password column
- Add unit test verifying password column is not unique
- Update Maven repositories to HTTPS and modern `maven-resources-plugin`

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to sonatype mirror (https://repo1.maven.org/maven2/): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ee5ec60a4832a8fc58f2fafa9f9e5