### PR TITLE
chore: update library versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,38 +14,38 @@
     <packaging>war</packaging>
 
     <properties>
-        <jdk.target>1.7</jdk.target>
-        <jdk.source>1.7</jdk.source>
+        <jdk.target>17</jdk.target>
+        <jdk.source>17</jdk.source>
         <show.deprecations>false</show.deprecations>
 
-        <junit.version>4.11</junit.version>
-        <jsonpath.version>0.9.1</jsonpath.version>
+        <junit.version>4.13.2</junit.version>
+        <jsonpath.version>2.9.0</jsonpath.version>
 
         <jstl.version>1.2</jstl.version>
-        <servlet-api.version>3.1.0</servlet-api.version>
-        <jsp-api.version>2.3.1</jsp-api.version>
+        <servlet-api.version>6.0.0</servlet-api.version>
+        <jsp-api.version>3.1.1</jsp-api.version>
 
-        <hibernate.version>4.3.6.Final</hibernate.version>
-        <hibernate.annotations.version>4.0.4.Final</hibernate.annotations.version>
-        <hibernate-validator.version>5.1.2.Final</hibernate-validator.version>
-        <hsqldb.version>2.3.2</hsqldb.version>
-        <ehcache.version>2.8.3</ehcache.version>
-        <c3p0.version>0.9.2.1</c3p0.version>
+        <hibernate.version>5.6.15.Final</hibernate.version>
+        <hibernate.annotations.version>5.1.0.Final</hibernate.annotations.version>
+        <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
+        <hsqldb.version>2.7.2</hsqldb.version>
+        <ehcache.version>2.10.9.2</ehcache.version>
+        <c3p0.version>0.9.5.5</c3p0.version>
 
-        <slf4j.version>1.7.7</slf4j.version>
-        <log4j.version>2.0.1</log4j.version>
+        <slf4j.version>2.0.9</slf4j.version>
+        <log4j.version>2.22.1</log4j.version>
 
-        <spring.framework.version>4.0.6.RELEASE</spring.framework.version>
-        <spring.security.version>3.2.4.RELEASE</spring.security.version>
-        <spring.data.core.version>1.8.2.RELEASE</spring.data.core.version>
-        <spring.data.jpa.version>1.6.2.RELEASE</spring.data.jpa.version>
+        <spring.framework.version>5.3.31</spring.framework.version>
+        <spring.security.version>5.8.10</spring.security.version>
+        <spring.data.core.version>3.2.5</spring.data.core.version>
+        <spring.data.jpa.version>3.2.5</spring.data.jpa.version>
 
-        <oval.version>1.84</oval.version>
-        <jackson.version>2.4.1</jackson.version>
-        <guava.version>17.0</guava.version>
+        <oval.version>3.4.0</oval.version>
+        <jackson.version>2.17.1</jackson.version>
+        <guava.version>33.2.1-jre</guava.version>
 
         <!--Container-->
-        <jetty.version>9.2.2.v20140723</jetty.version>
+        <jetty.version>12.0.4</jetty.version>
 
         <maven.test.skip>false</maven.test.skip>
 
@@ -53,25 +53,6 @@
             best of all from the context root-->
         <war.name>ROOT</war.name>
     </properties>
-
-    <repositories>
-	<repository>
-	    <id>sonatype</id>
-	    <url>http://search.maven.org/remotecontent?filepath=</url>
-	</repository>
-        <repository>
-            <id>JBOSS</id>
-            <url>http://repository.jboss.org/nexus/content/groups/public</url>
-        </repository>
-    </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>sonatype mirror</id>
-            <url>http://search.maven.org/remotecontent?filepath=</url>
-        </pluginRepository>
-    </pluginRepositories>
-
     <dependencies>
         <!--Test dependencies-->
         <dependency>


### PR DESCRIPTION
## Summary
- bump JDK and dependency versions to recent releases
- drop custom Maven repository definitions to rely on central

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:2.6 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ee62b1d9c832abf7b7905be9b2e25