### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Here is a stack of Javascript-based technologies:
 
 - [Datatables](http://datatables.net/) &mdash; jQuery-based tables plugin;
 
-- [jQuery Validation plugin](http://bassistance.de/jquery-plugins/jquery-plugin-validation/) &mdash; clien-side from validation;
+- [jQuery Validation plugin](http://bassistance.de/jquery-plugins/jquery-plugin-validation/) &mdash; client-side form validation.
 
 - [HandlebarsJS](http://handlebarsjs.com/) &mdash; [Mustache](http://mustache.github.com/)-like template engine with pre-compilation;
 


### PR DESCRIPTION
## Summary
- fix spelling in README for jQuery Validation plugin description

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f0ac10ec8832a92f0b8ee98421fc1