### PR TITLE
Throw exception when user not found

### DIFF
--- a/src/main/java/com/aimprosoft/glossary/common/security/GlossaryUserDetailsService.java
+++ b/src/main/java/com/aimprosoft/glossary/common/security/GlossaryUserDetailsService.java
@@ -25,7 +25,7 @@ public class GlossaryUserDetailsService implements UserDetailsService{
         User user = userService.getUserByEmail(username);
 
         if (user == null){
-            return null;
+            throw new UsernameNotFoundException("User not found: " + username);
         }
 
         GlossaryUserDetails userDetails = new GlossaryUserDetails(


### PR DESCRIPTION
## Summary
- Throw UsernameNotFoundException in `GlossaryUserDetailsService` when a user lookup fails

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f0ac3a068832abd30c689b7522807