### PR TITLE
docs: clarify glossary retrieval test comments

### DIFF
--- a/src/test/java/com/aimprosoft/glossary/test/RestTest.java
+++ b/src/test/java/com/aimprosoft/glossary/test/RestTest.java
@@ -110,7 +110,7 @@ public class RestTest extends BaseTest{
         assertThat(glossaryPersistence.exists(id), is(true));
 
         mockMvc
-                //call glossaries list with incorrect parameters
+                //call existing glossary by ID
                 .perform(get("/glossaries/" + id).contentType(MediaType.APPLICATION_JSON))
                 //expect result is valid
                 .andExpect(status().isOk())
@@ -129,7 +129,7 @@ public class RestTest extends BaseTest{
         assertThat(glossaryPersistence.exists(id), is(false));
 
         mockMvc
-                //call glossaries list with incorrect parameters
+                //call non-existing glossary by ID
                 .perform(get("/glossaries/" + id).contentType(MediaType.APPLICATION_JSON))
                 //expect result is invalid
                 .andExpect(status().isBadRequest())


### PR DESCRIPTION
## Summary
- clarify comments for tests retrieving glossaries by ID

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f0ac57d1c832ab1a8010339de3371